### PR TITLE
Add pip upgrade instruction to installs

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -29,9 +29,9 @@ author = 'Josh Tauberer, Greg Elin, Peter Kaminski, Ethan Kaminski'
 github_doc_root = 'https://github.com/GovReady/govready-q/tree/master/docs'
 
 # The short X.Y version
-version = 'v0.9.1.38.1'
+version = 'v0.9.1.45'
 # The full version, including alpha/beta/rc tags
-release = 'v0.9.1.38.1'
+release = 'v0.9.1.45'
 
 
 # -- General configuration ---------------------------------------------------

--- a/source/installation-and-setup/desktop-installation/macos.rst
+++ b/source/installation-and-setup/desktop-installation/macos.rst
@@ -36,6 +36,22 @@ Now install Python3 and the required Unix packages.
     # search the web for "wkhtmltopdf Server-Side Request Forgery"
     read -p "Are you sure (yes/no)? " ; if [ "$REPLY" = "yes" ]; then brew cask install wkhtmltopdf ; fi
 
+   # Upgrade pip to version 20.1+ - IMPORTANT
+   python3 -m pip install --upgrade pip
+
+   # Optionally install supervisord for monitoring and restarting GovReady-q; and NGINX as a reverse proxy
+   apt-get install -y supervisor nginx
+
+   # To optionally generate thumbnails and PDFs for export, you must install wkhtmltopdf
+   # WARNING: wkhtmltopdf can expose you to security risks. For more information,
+   # search the web for "wkhtmltopdf Server-Side Request Forgery"
+   read -p "Are you sure you need to generate PDF files (yes/no)? " ; if [ "$REPLY" = "yes" ]; then apt-get install wkhtmltopdf ; fi
+
+.. warning::
+   The default version 9.0.x of pip installed on Ubuntu (May 2020) correctly installs Python packages when run as root, but fails when run as non-root user and does not report the error clearly. (Pip 9.0.x fails to create the user's ``.local`` directory for installing the packages.)
+   Upgrading pip to version 20.x solves this problem. Pip must be upgraded to 20.x for the ``./install-govready-q`` script to properly install the
+   Python packages.
+
 Installing GovReady-Q
 ~~~~~~~~~~~~~~~~~~~~~
 

--- a/source/installation-and-setup/server-based-installation/linux/centos7/index.rst
+++ b/source/installation-and-setup/server-based-installation/linux/centos7/index.rst
@@ -42,7 +42,7 @@ provide full functionality. Execute the following commands as root:
    unzip jq \
    graphviz pandoc
 
-   # Upgrade pip to version 20.1+
+   # Upgrade pip to version 20.1+ - IMPORTANT
    pip3 install --upgrade pip
 
    # Optionally install supervisord for monitoring and restarting GovReady-q; and NGINX as a reverse proxy

--- a/source/installation-and-setup/server-based-installation/linux/centos8/index.rst
+++ b/source/installation-and-setup/server-based-installation/linux/centos8/index.rst
@@ -44,7 +44,7 @@ provide full functionality. Execute the following commands as root:
    dnf config-manager --set-enabled PowerTools
    dnf install pandoc
 
-   # Upgrade pip to version 20.1+
+   # Upgrade pip to version 20.1+ - IMPORTANT
    pip install --upgrade pip
 
    # Optionally install supervisord for monitoring and restarting GovReady-q; and NGINX as a reverse proxy

--- a/source/installation-and-setup/server-based-installation/linux/ubuntu/index.rst
+++ b/source/installation-and-setup/server-based-installation/linux/ubuntu/index.rst
@@ -44,7 +44,7 @@ provide full functionality. Execute the following commands as root:
    gunicorn3 \
    language-pack-en-base language-pack-en
 
-   # Upgrade pip to version 20.1+
+   # Upgrade pip to version 20.1+ - IMPORTANT
    python3 -m pip install --upgrade pip
 
    # Optionally install supervisord for monitoring and restarting GovReady-q; and NGINX as a reverse proxy


### PR DESCRIPTION
It is important to upgrade pip to v20.x.
Install will have problems, particularly gunicorn and gevent,
with Pip 9.x.

Update installs for MacOS and CentOS to upgrade pip.
Pip may also need to be upgraded for Windows.