### PR TITLE
Update branding sectio to clarify deploying branding.

### DIFF
--- a/source/production-deployment-topics/applying-custom-organization-branding.rst
+++ b/source/production-deployment-topics/applying-custom-organization-branding.rst
@@ -1,4 +1,4 @@
-.. Copyright (C) 2020 GovReady PBC
+.. Copyright (C) 2020, 2021 GovReady PBC
 
 .. _Applying Custom Organization Branding:
 
@@ -6,7 +6,7 @@ Applying Custom Organization Branding
 =====================================
 
 The look and feel of GovReady-Q can be customized a bit by overriding
-the Django templates that are used to construct the site’s pages and by
+the Django templates used to construct the site’s pages and by
 serving additional static assets.
 
 Custom branding can contain static assets (such as a logo image) and
@@ -16,15 +16,19 @@ GovReady-Q to find the branding files. The directory is placed inside
 the main GovReady-Q directory, and an application setting is used to
 activate it.
 
-Before setting out to create custom branding, make sure you have
-GovReady-Q :ref:`set up for development on your
-workstation <Developing for Govready-Q>`. You’ll need a working setup of
-GovReady-Q to create the branding directory and to test your changes.
+Storing the branding files in a single, separate directory insures
+maintaining and updating your branding files and GovReady-Q
+files from the official repository are independent activities.
 
 Creating the branding directory
 -------------------------------
 
-Custom branding is packaged inside what Django confusingly calls an
+You’ll need a working setup of GovReady-Q to create the branding directory
+and to test your changes. Make sure you have
+GovReady-Q :ref:`set up for development on your
+workstation <Developing for Govready-Q>`.
+
+Custom branding is packaged inside what Django calls an
 `application <https://docs.djangoproject.com/en/2.1/ref/applications/>`__,
 but it is just a packaged sub-component of a website. To create a new
 branding package directory, change to the directory where you have
@@ -32,17 +36,28 @@ GovReady-Q set up. Then run:
 
 .. code:: sh
 
-   python3 manage.py startapp sample_branding
+   python3 manage.py startapp branding
 
-This command creates a new directory called ``sample_branding`` with
-Python boilerplate code to make it a valid Django “application.”
+This command creates a new directory called ``branding`` with
+Python boilerplate code to make it a valid Django "application."
 
 Make directories for storing the custom static assets and templates:
 
 .. code:: sh
 
-   mkdir sample_branding/static
-   mkdir sample_branding/templates
+   mkdir branding/static
+   mkdir branding/templates
+
+.. note::
+   The directory with custom branding is called ``branding`` by convention,
+   but you can chose any name because the path is set by explicit reference
+   in your ``local/environment.json`` file. (GovReady-Q's ``.gitignore``
+   file includes the ``branding`` directory.)
+
+   You will only need to go through the above process to initially
+   create your custom branding Django application folder. Once created,
+   you only need to include and activate your custom branding directory in other instances
+   of GovReady-Q for your branding to be applied.
 
 Activate the branding package
 -----------------------------
@@ -54,11 +69,11 @@ custom branding package directory.
 
 .. code:: sh
 
-     "branding": "sample_branding",
+     "branding": "branding",
 
 See :ref:`Configuration with Environment Variables` for more information
-about the ``local/environment.json`` file. Note that for the file to be
-valid JSON the last setting cannot have a trailing comma.
+about the ``local/environment.json`` file. (Note that for the file to be
+valid JSON the last setting cannot have a trailing comma.)
 
 Overriding templates
 --------------------
@@ -71,7 +86,7 @@ https://github.com/GovReady/govready-q/tree/master/templates
 
 Start by trying to override the ``navbar.html`` template, which is
 inserted at the top of every page. Use your favorite text editor to
-create a file at ``sample_branding/templates/navbar.html``. Copy the
+create a file at ``branding/templates/navbar.html``. Copy the
 content of GovReady-Q’s stock ``navbar.html`` from
 https://github.com/GovReady/govready-q/blob/master/templates/navbar.html
 into it. (GitHub’s “Raw” button is handy for getting a clean version to
@@ -101,7 +116,7 @@ b) Insert a ``<link rel="stylesheet" href="...">`` tag into the
    ``head.html`` template.
 
 To create the static asset, make a new file named
-``sample_branding/static/custom.css``. Let’s say you want to make the
+``branding/static/custom.css``. Let’s say you want to make the
 background color of each page red. The file should contain:
 
 .. code:: css
@@ -113,7 +128,7 @@ background color of each page red. The file should contain:
 Then override the ``head.html`` template. GovReady-Q’s base for
 ``head.html`` is empty — its purpose is only to allow you to add to the
 ``<head>`` element. So create a new file at
-``sample_branding/templates/head.html`` and put in it:
+``branding/templates/head.html`` and put in it:
 
 .. code:: jinja
 
@@ -127,12 +142,28 @@ more information about the ``static`` template tag.
 Open any page in your locally running GovReady-Q and you should see that
 the background color of every page has changed.
 
+Deploying your custom branding in production
+--------------------------------------------
+
+Deploying your custom branding to production is simply a matter of including
+your custom branding directory along with with your production deployment of
+GovReady-Q and adding the ``branding`` environmental parameter to your
+production ``local/environment.json`` file.
+
 Keeping your templates up to date
 ---------------------------------
 
 With each new released version of GovReady-Q, there is the possibility
 that the stock templates have changed. Some changes may require you to
 re-engineer your template overrides to preserve functionality.
+
+The deeper your customization, the more you will need to look at new
+releases of GovReady-Q for changes that update pages and page elements you
+have customized (like a new menu item) and new pages and section to which
+you may want to customize with your branding.
+
+If you are able to implement all your branding in CSS, you will rarely
+need to change your branding files.
 
 Creating a custom Docker image
 ------------------------------
@@ -155,7 +186,7 @@ Creating your own Dockerfile that uses a released GovReady-Q image as its parent
 We recommend method 2. To create your own Dockerfile that uses a
 released GovReady-Q image as its parent image, create a new
 ``Dockerfile`` in your branding package directory, e.g. a new file named
-``Dockerfile`` in the ``sample_branding`` directory you created earlier.
+``Dockerfile`` in the ``branding`` directory you created earlier.
 
 Then choose which parent image you will use from the available
 `GovReady-Q tags <https://hub.docker.com/r/govready/govready-q/tags>`__.
@@ -227,7 +258,7 @@ package directory:
 
 .. code:: bash
 
-   cd sample_branding
+   cd branding
 
 Then fetch the parent image and build your image:
 


### PR DESCRIPTION
Clarify that deploying styles requires only copying the created styles,
not recreating the Django application for the branded folder each time.