### PR TITLE
chromedriver install on macos update

### DIFF
--- a/source/testing-for-govready-q/automated-testing.rst
+++ b/source/testing-for-govready-q/automated-testing.rst
@@ -14,7 +14,7 @@ To run the integration tests, you'll also need to install chromedriver:
 .. code-block:: bash
 
    sudo apt-get install chromium-chromedriver   (on Ubuntu)
-   brew cask install chromedriver               (on Mac)
+   brew install --cask chromedriver               (on Mac)
 
 Navigate within your terminal to GovReady-Q top level directory.
 


### PR DESCRIPTION
brew on macos currently uses cask as an option with two hashes as seen here:

https://formulae.brew.sh/cask/chromedriver

So the command has been updated to:

brew install --cask chromedriver